### PR TITLE
build: upgrade node, yarn, nvm, and etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This image builds on top of the [`selenium/standalone-chrome`](https://hub.docke
 * [`npm`](https://www.npmjs.com/)
 * [`yarn`](https://yarnpkg.com)
 * [`awscli`](https://aws.amazon.com/cli/)
-* [`python3`](https://www.python.org/) (needed for AWS CLI)
 * And an additional set of Chromium dependencies
 
 The exact binary versions provided with each release are available in their corresponding release notes.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -27,7 +27,7 @@ RUN sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh
 
 # node and yarn environment variables
 ENV HOME /home/seluser
-ENV NVM_DIR $HOME/nvm
+ENV NVM_DIR $HOME/.nvm
 ENV NODE_VERSION 8.11.2
 ENV YARN_VERSION 1.6.0
 
@@ -38,7 +38,8 @@ RUN mkdir -p $HOME && chown -R seluser:seluser $HOME
 USER seluser
 
 # Install nvm (https://github.com/creationix/nvm#install-script)
-RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+RUN mkdir -p $NVM_DIR \
+    && curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 RUN source $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -yq libgconf-2-4
 ENV CHROME_BIN /usr/bin/google-chrome
 
 # `dumb-init` helps prevent zombie chrome processes.
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 ENTRYPOINT ["dumb-init", "--"]
 
@@ -28,8 +28,8 @@ RUN sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh
 # node and yarn environment variables
 ENV HOME /home/seluser
 ENV NVM_DIR $HOME/nvm
-ENV NODE_VERSION 8.9.4
-ENV YARN_VERSION 1.3.2
+ENV NODE_VERSION 8.11.2
+ENV YARN_VERSION 1.6.0
 
 # Set home permissions for seluser
 RUN mkdir -p $HOME && chown -R seluser:seluser $HOME
@@ -38,7 +38,7 @@ RUN mkdir -p $HOME && chown -R seluser:seluser $HOME
 USER seluser
 
 # Install nvm (https://github.com/creationix/nvm#install-script)
-RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 RUN source $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
@@ -56,6 +56,8 @@ RUN $CHROME_BIN --version
 RUN node --version
 RUN npm --version
 RUN yarn --version
+RUN python3 --version
+RUN awscli --version
 
 # Set working directory to home
 WORKDIR $HOME

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -57,8 +57,7 @@ RUN $CHROME_BIN --version
 RUN node --version
 RUN npm --version
 RUN yarn --version
-RUN python3 --version
-RUN awscli --version
+RUN aws --version
 
 # Set working directory to home
 WORKDIR $HOME


### PR DESCRIPTION
Upgrades `node@8.11.2`, `yarn@1.6.0`, `nvm@0.33.11`, and pulls from latest `selenium/standalone-chrome`